### PR TITLE
Catch the error run of normalmixEM for each each

### DIFF
--- a/R/binarization.R
+++ b/R/binarization.R
@@ -73,7 +73,7 @@ binarize_exp <- function(sce, fix_cutoff = FALSE, binarize_cutoff = 0.2, ncores 
     oupBinary$passBinary = TRUE
     oupBinary[oupBinary$lambda1 < 0.1, ]$passBinary = FALSE
     oupBinary[oupBinary$lambda2 < 0.1, ]$passBinary = FALSE
-    oupBinary[(as.numeric(oupBinary$mu2) - as.numeric(oupBinary$mu1)) < (oupBinary$sigma1 + oupBinary$sigma2), ]$passBinary = FALSE
+    oupBinary[(as.numeric(oupBinary$mu2) - as.numeric(oupBinary$mu1)) < ( as.numeric(oupBinary$sigma1) + as.numeric(oupBinary$sigma2) ), ]$passBinary = FALSE
     # table(oupBinary$passBinary)
 
     # Solve for intersection for remaining genes

--- a/R/binarization.R
+++ b/R/binarization.R
@@ -73,7 +73,7 @@ binarize_exp <- function(sce, fix_cutoff = FALSE, binarize_cutoff = 0.2, ncores 
     oupBinary$passBinary = TRUE
     oupBinary[oupBinary$lambda1 < 0.1, ]$passBinary = FALSE
     oupBinary[oupBinary$lambda2 < 0.1, ]$passBinary = FALSE
-    oupBinary[(oupBinary$mu2 - oupBinary$mu1) < (oupBinary$sigma1 + oupBinary$sigma2), ]$passBinary = FALSE
+    oupBinary[(as.numeric(oupBinary$mu2) - as.numeric(oupBinary$mu1)) < (oupBinary$sigma1 + oupBinary$sigma2), ]$passBinary = FALSE
     # table(oupBinary$passBinary)
 
     # Solve for intersection for remaining genes

--- a/R/binarization.R
+++ b/R/binarization.R
@@ -73,7 +73,9 @@ binarize_exp <- function(sce, fix_cutoff = FALSE, binarize_cutoff = 0.2, ncores 
     oupBinary$passBinary = TRUE
     oupBinary[oupBinary$lambda1 < 0.1, ]$passBinary = FALSE
     oupBinary[oupBinary$lambda2 < 0.1, ]$passBinary = FALSE
-    oupBinary[(as.numeric(oupBinary$mu2) - as.numeric(oupBinary$mu1)) < ( as.numeric(oupBinary$sigma1) + as.numeric(oupBinary$sigma2) ), ]$passBinary = FALSE
+    no_pass_binary <- c(as.numeric(oupBinary$mu2) - as.numeric(oupBinary$mu1)) < c( as.numeric(oupBinary$sigma1) + as.numeric(oupBinary$sigma2) )
+    no_pass_binary[is.na(no_pass_binary)] <- T
+    oupBinary[no_pass_binary, ]$passBinary = FALSE
     # table(oupBinary$passBinary)
 
     # Solve for intersection for remaining genes

--- a/R/binarization.R
+++ b/R/binarization.R
@@ -47,7 +47,14 @@ binarize_exp <- function(sce, fix_cutoff = FALSE, binarize_cutoff = 0.2, ncores 
     oupBinary = do.call(
       rbind, mclapply(rownames(LogCountsadd), function(iGene){
         set.seed(42)   # Set seed for consistency
-        tmpMix = normalmixEM(LogCountsadd[iGene, ], k = 2)
+        tmpMix = try(normalmixEM(LogCountsadd[iGene, ], k = 2))
+        if (inherits(tmpMix, 'try-error')) {
+          tmpOup = data.frame(
+            geneID = iGene,
+            mu1 = NA, mu2 = NA, 
+            sigma1=NA, sigma2=NA, lambda1=NA, lambda2=NA, loglik=NA)
+          return(tmpOup)
+        }
         if (tmpMix$mu[1] < tmpMix$mu[2]) {
           tmpOup = data.frame(geneID = iGene,
                               mu1 = tmpMix$mu[1],
@@ -73,7 +80,7 @@ binarize_exp <- function(sce, fix_cutoff = FALSE, binarize_cutoff = 0.2, ncores 
     oupBinary$passBinary = TRUE
     oupBinary[oupBinary$lambda1 < 0.1, ]$passBinary = FALSE
     oupBinary[oupBinary$lambda2 < 0.1, ]$passBinary = FALSE
-    no_pass_binary <- c(as.numeric(oupBinary$mu2) - as.numeric(oupBinary$mu1)) < c( as.numeric(oupBinary$sigma1) + as.numeric(oupBinary$sigma2) )
+    no_pass_binary <- c(oupBinary$mu2 - oupBinary$mu1) < c(oupBinary$sigma1 + oupBinary$sigma2)
     no_pass_binary[is.na(no_pass_binary)] <- T
     oupBinary[no_pass_binary, ]$passBinary = FALSE
     # table(oupBinary$passBinary)


### PR DESCRIPTION
See issue #3. 

For some genes, binarization fails. In this case, the output of normalmixEM will be "Error in mixtools::normalmixEM(LogCountsadd[iGene, ], k = 2) : \n  Too many tries!\n" for example. Therefore, it messes up the data frame `oupBinary`'s structure, which further propagates to decide `oupBinary$passBinary`.

A quick fix is to return NA for those genes and mark passBinary=F for them.